### PR TITLE
Change image source to fix missing images

### DIFF
--- a/components/OperatorGridItem.vue
+++ b/components/OperatorGridItem.vue
@@ -25,7 +25,7 @@ await useOperatorsIndexLocale(i18n)
       :class="`bg-rarity-${operator.rarity}-item hover:bg-rarity-${operator.rarity}-item-focus focus-visible:bg-rarity-${operator.rarity}-item-focus`"
     >
       <UAvatar
-        :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/avatars/${encodeURI(
+        :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/charavatars/${encodeURI(
           operator.phases[0].outfit!.avatarId
         )}.png`"
         :alt="name"

--- a/components/OperatorIntroductionCard.vue
+++ b/components/OperatorIntroductionCard.vue
@@ -37,7 +37,7 @@ await useOperatorLocale(i18n, operator.key)
         <div class="flex">
           <img
             class="h-9 w-9 rounded-l-theme bg-gray-900 object-contain p-0.5"
-            :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/ui/subclass/sub_${operator.classBranch}_icon.png`"
+            :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/ui/subprofessionicon/sub_${operator.classBranch}_icon.png`"
           />
           <div>
             <div

--- a/components/OperatorLevelSelectWidget.vue
+++ b/components/OperatorLevelSelectWidget.vue
@@ -95,7 +95,7 @@ function changeElite(eliteChoice: number) {
             :class="{
               'brightness-90': elite !== eliteChoice,
             }"
-            :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/ui/elite/${eliteChoice}.png`"
+            :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/arts/elite_${eliteChoice}.png`"
           />
         </button>
       </li>

--- a/components/OperatorLink.vue
+++ b/components/OperatorLink.vue
@@ -21,7 +21,7 @@ await useOperatorsIndexLocale(i18n)
     :class="`bg-rarity-${operator.rarity}-item hover:bg-rarity-${operator.rarity}-item-focus focus-visible:bg-rarity-${operator.rarity}-item-focus`"
   >
     <UAvatar
-      :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/avatars/${encodeURI(
+      :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/charavatars/${encodeURI(
         operator.phases[0].outfit!.avatarId,
       )}.png`"
       :alt="name"
@@ -44,7 +44,7 @@ await useOperatorsIndexLocale(i18n)
       <UTooltip class="h-8 w-8">
         <img
           class="h-full w-full rounded-theme bg-gray-700 object-contain p-0.5 group-hover:bg-gray-900 group-focus-visible:bg-gray-900"
-          :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/ui/subclass/sub_${operator.classBranch}_icon.png`"
+          :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/ui/subprofessionicon/sub_${operator.classBranch}_icon.png`"
         />
         <template #text>
           {{ t(`operator.classBranch.${operator.classBranch}`) }}

--- a/components/OperatorModuleWidget.vue
+++ b/components/OperatorModuleWidget.vue
@@ -112,13 +112,13 @@ await useOperatorLocale(i18n, operator.key)
           class="h-12 w-12 rounded-theme bg-gray-900 bg-contain bg-center bg-no-repeat p-1"
           :style="{
             backgroundImage: module.stages
-              ? `url('https://raw.githubusercontent.com/Aceship/Arknight-Images/main/equip/shining/${module.shiningColor}_shining.png')`
+              ? `url('https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/ui/uniequipcolorshining/${module.shiningColor}_shining.png')`
               : undefined,
           }"
         >
           <img
             class="h-full w-full object-contain"
-            :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/equip/type/${module.typeIcon.toLowerCase()}.png`"
+            :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/ui/uniequiptype/${module.typeIcon.toLowerCase()}.png`"
           />
         </div>
         <div class="flex flex-col">
@@ -146,7 +146,7 @@ await useOperatorLocale(i18n, operator.key)
         >
           <img
             :class="{ 'opacity-90': moduleState.potential !== potential }"
-            :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/ui/potential/${potential}.png`"
+            :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/arts/potential_${potential-1}.png`"
           />
         </button>
       </div>
@@ -318,8 +318,8 @@ await useOperatorLocale(i18n, operator.key)
         <div>
           <img
             class="mx-auto w-72 md:float-right md:mx-4 lg:w-80"
-            :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/equip/icon/${
-              module.type === 'INITIAL' ? 'original' : module.icon
+            :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/ui/uniequipimg/${
+              module.type === 'INITIAL' ? 'default' : module.icon
             }.png`"
           />
           <span

--- a/components/OperatorPotentialTrustList.vue
+++ b/components/OperatorPotentialTrustList.vue
@@ -95,7 +95,7 @@ await useOperatorLocale(i18n, operator.key)
             class="block h-6 w-6 flex-shrink-0 rounded-theme bg-gray-900 p-0.5"
           >
             <img
-              src="https://raw.githubusercontent.com/Aceship/Arknight-Images/main/ui/potential/1.png"
+              src="https://raw.githubusercontent.com/akgcc/arkdata/main/assets/arts/potential_0_small.png"
             />
           </div>
           <div>{{ t("operator.ui.operatorRecruited") }}</div>
@@ -128,7 +128,7 @@ await useOperatorLocale(i18n, operator.key)
                 'opacity-90':
                   operatorState.potential < potential.potentialNumber,
               }"
-              :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/ui/potential/${potential.potentialNumber}.png`"
+              :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/arts/potential_${potential.potentialNumber-1}_small.png`"
             />
           </div>
           <div>

--- a/components/OperatorRiicBaseSkillWidget.vue
+++ b/components/OperatorRiicBaseSkillWidget.vue
@@ -33,7 +33,7 @@ await useOperatorLocale(i18n, operator.key)
         <!-- Name, icon -->
         <img
           class="h-8 w-8"
-          :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/ui/infrastructure/skill/${encodeURI(
+          :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/building/skills/${encodeURI(
             skill.skillIcon,
           )}.png`"
         />
@@ -50,7 +50,7 @@ await useOperatorLocale(i18n, operator.key)
           >
             <img
               class="object-contain"
-              :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/ui/elite/${skill.unlockConditions.elite}.png`"
+              :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/arts/elite_${skill.unlockConditions.elite}.png`"
             />
           </div>
           <div v-if="skill.unlockConditions.level !== 1">

--- a/components/OperatorSearchBar.vue
+++ b/components/OperatorSearchBar.vue
@@ -158,7 +158,7 @@ await useOperatorsIndexLocalePromise
         <UTooltip class="h-8 w-8" :ui="{ popper: { strategy: 'absolute' } }">
           <img
             class="h-full w-full rounded-theme bg-gray-700 object-contain p-0.5 group-hover:bg-gray-900 group-focus-visible:bg-gray-900"
-            :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/ui/subclass/sub_${cmdOperator.classBranch}_icon.png`"
+            :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/ui/subprofessionicon/sub_${cmdOperator.classBranch}_icon.png`"
           />
           <template #text>
             {{ t(`operator.classBranch.${cmdOperator.classBranch}`) }}

--- a/components/OperatorSkillWidgetIntroductionCard.vue
+++ b/components/OperatorSkillWidgetIntroductionCard.vue
@@ -29,7 +29,7 @@ await useOperatorLocale(i18n, ownerOperatorKey ?? operator.key)
       class="rounded-theme"
       v-if="skill.levels[0].hasDescription"
       :class="{ 'h-14 w-14': small, 'h-16 w-16': !small }"
-      :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/skills/skill_icon_${
+      :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/skills/skill_icon_${
         skill.iconId || skill.id
       }.png`"
     />

--- a/components/OperatorTalentWidget.vue
+++ b/components/OperatorTalentWidget.vue
@@ -126,7 +126,7 @@ await useOperatorLocale(i18n, operator.key)
           "
         >
           <img
-            :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/ui/elite/${elite}.png`"
+            :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/arts/elite_${elite}.png`"
             :class="{
               'opacity-90':
                 talentState.elite !== elite || talentState.level !== level,
@@ -162,7 +162,7 @@ await useOperatorLocale(i18n, operator.key)
         >
           <img
             :class="{ 'opacity-90': talentState.potential !== potential }"
-            :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/ui/potential/${potential}.png`"
+            :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/arts/potential_${potential-1}.png`"
           />
         </button>
       </div>

--- a/components/OperatorTokenSummonWidget.vue
+++ b/components/OperatorTokenSummonWidget.vue
@@ -26,7 +26,7 @@ const tokenSummonKey = computed<string>(
 )
 
 const currentAvatarUrl = computed<string>(() =>
-  getAvatarUrl(tokenSummon, operatorState)
+  getAvatarUrl(tokenSummon, { ...operatorState, elite: 0 })
 )
 
 const currentPhase = computed<GeneratedElitePhaseData>(

--- a/components/RandomOperatorWidget.vue
+++ b/components/RandomOperatorWidget.vue
@@ -14,7 +14,7 @@ function getPortraitUrl(elite: number): string | null {
       operator.phases[0].outfit?.portraitId
   )
     return null
-  return `https://raw.githubusercontent.com/Aceship/Arknight-Images/main/characters/${encodeURI(
+  return `https://raw.githubusercontent.com/akgcc/arkdata/main/assets/chararts/${encodeURI(
     operator.phases[elite].outfit!.portraitId!
   )}.png`
 }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -44,7 +44,7 @@ export function getAvatarUrl(
   while (!phase.outfit?.avatarId && phase.elite !== 0)
     phase = operator.phases[phase.elite - 1]
 
-  return `https://raw.githubusercontent.com/Aceship/Arknight-Images/main/avatars/${encodeURI(
+  return `https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/charavatars/${encodeURI(
     phase.outfit!.avatarId
   )}.png`
 }


### PR DESCRIPTION
Since aceship images haven't been updated in a few months, you can use [this](https://github.com/akgcc/arkdata) as an alternative. I replaced everything except the main class icons (because you have mapped them to the aceship names and I didn't want to break anything) and the mastery icons (because I couldn't locate them in the game files). If you want to switch the class icons the paths should be `https://raw.githubusercontent.com/akgcc/arkdata/main/assets/arts/icon_profession_${original_class_name}.png`

This source is updated via github actions directly from Hypergryph so it should remain up to date unless HG changes something and breaks it. Feel free to let me know if there are any other images you need and I will try to find them and add them to the arkdata config.

I also noticed that some skill tokens (Wisadel, for example) had broken paths due to attempting to fetch the e2 version of the icon, so the second commit just forces tokens to e0 as a fix.