### PR TITLE
fix: useRegisteredLocales must call useI18n in setup, not in computed getter

### DIFF
--- a/composables/useRegisteredLocales.ts
+++ b/composables/useRegisteredLocales.ts
@@ -1,16 +1,14 @@
 import type { LocaleObject } from "@nuxtjs/i18n/dist/runtime/composables"
 
-const registeredLocales = computed<LocaleObject[]>(() => {
-  const { locales } = useI18n({ useScope: "global" })
-  return locales.value.map((localeObjOrCode) => {
-    if (typeof localeObjOrCode === "object") return localeObjOrCode
-    return {
-      code: localeObjOrCode,
-      name: localeObjOrCode,
-    }
-  })
-})
-
 export default function (): ComputedRef<LocaleObject[]> {
-  return registeredLocales
+  const { locales } = useI18n({ useScope: "global" })
+  return computed<LocaleObject[]>(() =>
+    locales.value.map((localeObjOrCode) => {
+      if (typeof localeObjOrCode === "object") return localeObjOrCode
+      return {
+        code: localeObjOrCode,
+        name: localeObjOrCode,
+      }
+    }),
+  )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`useRegisteredLocales` previously created a **module-level** `computed` whose getter called `useI18n()`. In Vue 3, composables must run synchronously during component (or composable) setup; calling them from inside a computed getter is invalid and can surface as SSR/runtime warnings or broken locale lists—consistent with the work on `cursor/development-environment-setup-303f` (SSR guard around the same pattern).

## Reproduction (conceptual)

1. Open `composables/useRegisteredLocales.ts` on `main`: the getter of `registeredLocales` invokes `useI18n({ useScope: "global" })`.
2. Per Vue’s composition API rules, that is only valid if it runs during `setup`; a `computed` getter runs later (e.g. on first read), so `useI18n` is not in a proper setup context when the ref is evaluated.

## Fix

Call `useI18n` inside `useRegisteredLocales()` and return a `computed` that only maps `locales.value`—no composables inside the getter.

## Testing

`pnpm exec nuxt build` currently fails in this environment with `TypeError: [vite:json] orgTransform.apply is not a function` on `locales/en-US/default.json` (unrelated to this one-line composable pattern). The change is localized and matches the intended Nuxt/Vue composable usage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78a30e71-d393-49d3-83a3-2e2a9bd43abf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78a30e71-d393-49d3-83a3-2e2a9bd43abf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

