### PR TITLE
Improve client navigation performance for static operators pages

### DIFF
--- a/components/OperatorGrid.vue
+++ b/components/OperatorGrid.vue
@@ -1,13 +1,43 @@
 <script setup lang="ts">
+const nuxtApp = useNuxtApp()
+
 const { data: operators } = await useAsyncData("operators", async () =>
-  useOperatorsIndexData()
+  useOperatorsIndexData(),
 )
+
+const list = operators.value ?? []
+const progressiveMount =
+  import.meta.client && !nuxtApp.isHydrating && list.length > 0
+const chunkSize = 80
+
+const visibleCount = ref(
+  progressiveMount ? Math.min(chunkSize, list.length) : list.length,
+)
+
+const visibleOperators = computed(() => {
+  const ops = operators.value ?? []
+  if (!progressiveMount) return ops
+  return ops.slice(0, visibleCount.value)
+})
+
+onMounted(() => {
+  if (!progressiveMount) return
+  const ops = operators.value ?? []
+  let end = visibleCount.value
+  const step = () => {
+    if (end >= ops.length) return
+    end = Math.min(ops.length, end + chunkSize)
+    visibleCount.value = end
+    requestAnimationFrame(step)
+  }
+  if (end < ops.length) requestAnimationFrame(step)
+})
 </script>
 
 <template>
   <ul class="operator-grid">
     <OperatorGridItem
-      v-for="operator in operators ?? []"
+      v-for="operator in visibleOperators"
       :key="operator.key"
       :operator="operator"
     />

--- a/components/OperatorGridItem.vue
+++ b/components/OperatorGridItem.vue
@@ -23,6 +23,7 @@ const name = computed(() => t(`${operator.key}.name`))
       :class="`bg-rarity-${operator.rarity}-item hover:bg-rarity-${operator.rarity}-item-focus focus-visible:bg-rarity-${operator.rarity}-item-focus`"
     >
       <UAvatar
+        loading="lazy"
         :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/charavatars/${encodeURI(
           operator.phases[0].outfit!.avatarId
         )}.png`"

--- a/components/OperatorGridItem.vue
+++ b/components/OperatorGridItem.vue
@@ -13,8 +13,6 @@ const { t } = i18n
 const localePath = useLocalePath()
 
 const name = computed(() => t(`${operator.key}.name`))
-
-await useOperatorsIndexLocale(i18n)
 </script>
 
 <template>

--- a/components/OperatorLink.vue
+++ b/components/OperatorLink.vue
@@ -21,6 +21,7 @@ await useOperatorsIndexLocale(i18n)
     :class="`bg-rarity-${operator.rarity}-item hover:bg-rarity-${operator.rarity}-item-focus focus-visible:bg-rarity-${operator.rarity}-item-focus`"
   >
     <UAvatar
+      loading="lazy"
       :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/charavatars/${encodeURI(
         operator.phases[0].outfit!.avatarId,
       )}.png`"
@@ -34,6 +35,7 @@ await useOperatorsIndexLocale(i18n)
     <div class="ml-auto flex items-center gap-1">
       <UTooltip class="h-8 w-8">
         <img
+          loading="lazy"
           class="h-full w-full rounded-theme bg-gray-700 object-contain p-0.5 group-hover:bg-gray-900 group-focus-visible:bg-gray-900"
           :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/classes/class_${operator.class.toLowerCase()}.png`"
         />
@@ -43,6 +45,7 @@ await useOperatorsIndexLocale(i18n)
       </UTooltip>
       <UTooltip class="h-8 w-8">
         <img
+          loading="lazy"
           class="h-full w-full rounded-theme bg-gray-700 object-contain p-0.5 group-hover:bg-gray-900 group-focus-visible:bg-gray-900"
           :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/ui/subprofessionicon/sub_${operator.classBranch}_icon.png`"
         />

--- a/components/OperatorSearchBar.vue
+++ b/components/OperatorSearchBar.vue
@@ -138,6 +138,7 @@ await useOperatorsIndexLocalePromise
   >
     <template #operators-icon="{ command: cmdOperator }">
       <UAvatar
+        loading="lazy"
         size="lg"
         :src="cmdOperator.avatar.src"
         :alt="cmdOperator.label"
@@ -148,6 +149,7 @@ await useOperatorsIndexLocalePromise
       <div class="flex items-center gap-1">
         <UTooltip class="h-8 w-8" :ui="{ popper: { strategy: 'absolute' } }">
           <img
+            loading="lazy"
             class="h-full w-full rounded-theme bg-gray-700 object-contain p-0.5 group-hover:bg-gray-900 group-focus-visible:bg-gray-900"
             :src="`https://raw.githubusercontent.com/Aceship/Arknight-Images/main/classes/class_${cmdOperator.class.toLowerCase()}.png`"
           />
@@ -157,6 +159,7 @@ await useOperatorsIndexLocalePromise
         </UTooltip>
         <UTooltip class="h-8 w-8" :ui="{ popper: { strategy: 'absolute' } }">
           <img
+            loading="lazy"
             class="h-full w-full rounded-theme bg-gray-700 object-contain p-0.5 group-hover:bg-gray-900 group-focus-visible:bg-gray-900"
             :src="`https://raw.githubusercontent.com/akgcc/arkdata/main/assets/torappu/dynamicassets/arts/ui/subprofessionicon/sub_${cmdOperator.classBranch}_icon.png`"
           />

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,6 +6,11 @@ function runTerminal(command: string): string {
 }
 
 export default defineNuxtConfig({
+  defaults: {
+    nuxtLink: {
+      prefetchOn: { visibility: true, interaction: true },
+    },
+  },
   app: {
     head: {
       meta: [

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,7 +8,12 @@ function runTerminal(command: string): string {
 export default defineNuxtConfig({
   defaults: {
     nuxtLink: {
-      prefetchOn: { visibility: true, interaction: true },
+      // Visibility prefetch on hundreds of grid links is expensive (observers + work).
+      // Interaction prefetch still warms routes on hover/focus; see plugins/preload-operator-routes.client.ts.
+      prefetchOn: { visibility: false, interaction: true },
+    },
+    useAsyncData: {
+      deep: false,
     },
   },
   app: {
@@ -154,7 +159,7 @@ export default defineNuxtConfig({
     },
   },
   devtools: {
-    enabled: true,
+    enabled: process.env.NODE_ENV !== "production",
   },
   nitro: {
     prerender: {

--- a/pages/operators/index.vue
+++ b/pages/operators/index.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 const { t } = useI18n()
+
+await useOperatorsIndexLocale(useI18n())
 </script>
 
 <template>

--- a/plugins/preload-operator-routes.client.ts
+++ b/plugins/preload-operator-routes.client.ts
@@ -1,0 +1,47 @@
+export default defineNuxtPlugin((nuxtApp) => {
+  if (import.meta.server) return
+
+  const router = useRouter()
+  const localePath = useLocalePath()
+
+  function scheduleIdle(cb: () => void) {
+    if (typeof requestIdleCallback === "function") {
+      requestIdleCallback(cb, { timeout: 2000 })
+    } else {
+      setTimeout(cb, 1)
+    }
+  }
+
+  function preloadKeys(keys: string[]) {
+    for (const key of keys) {
+      void preloadRouteComponents(localePath(`/operators/${key}`), router)
+    }
+  }
+
+  nuxtApp.hook("page:finish", () => {
+    const route = router.currentRoute.value
+    const segments = route.path.split("/").filter(Boolean)
+    const last = segments[segments.length - 1]
+    const isLocaleHome =
+      segments.length === 1 && ["en", "ja", "ko", "zh"].includes(segments[0]!)
+
+    if (segments.length === 0 || isLocaleHome) {
+      scheduleIdle(() => {
+        void preloadRouteComponents(localePath("/operators"), router)
+      })
+      return
+    }
+
+    if (last !== "operators" || route.params.key) return
+
+    queueMicrotask(() => {
+      const data = nuxtApp.payload.data.operators
+      if (!Array.isArray(data) || !data.length) return
+
+      const keys = data
+        .slice(0, 24)
+        .map((op: { key: string }) => op.key)
+      preloadKeys(keys)
+    })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Navigation and static-site performance improvements, plus lazy-loaded avatars in list contexts.

## Changes

### Navigation / static (earlier commits)
- Operators index locale loaded once; NuxtLink prefetch tuning; grid progressive mount; route preload plugin; shallow `useAsyncData` default; prod devtools off.

### Lazy avatars (latest)
- `loading="lazy"` on `UAvatar` and small class/branch icons in **OperatorGridItem**, **OperatorLink**, and **OperatorSearchBar** command palette rows.
- **Not** applied to operator detail hero (`OperatorIntroductionCard`), `og:image`, or home **RandomOperatorWidget** background — those stay eager for LCP / SEO / above-the-fold UX.

## Testing

- `pnpm run prepare-nuxt`
- Playwright perf suite as in CI when validating.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fcd0f47-dcc3-4685-b9ee-8cf6e599446f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fcd0f47-dcc3-4685-b9ee-8cf6e599446f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

